### PR TITLE
Remove -i, --information flag

### DIFF
--- a/argument_parser.c
+++ b/argument_parser.c
@@ -24,7 +24,6 @@ static char args_doc[] = "<server> <channel(s)> <bot cmds>";
 static struct argp_option options[] = {
 {"verbose",  'v', 0,      0,  "Produce verbose output", 0 },
 {"quiet",    'q', 0,      0,  "Don't produce any output", 0 },
-{"information",    'i', 0,      0,  "Produce information output.", 0 },
 {"checksum-verify", 'c', 0,      0,  "Stay connected after download completed to verify checksums.", 0 },
 {"ipv4",   '4', 0,      0,  "Use ipv4 to connect to irc server.", 0 },
 #ifdef ENABLE_IPV6
@@ -49,6 +48,7 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state) {
     /* Get the input argument from argp_parse, which we
       know is a pointer to our arguments structure. */
     struct xdccGetConfig *cfg = state->input;
+    cfg->logLevel = LOG_INFO;
 
     switch (key) {
     case 'q':
@@ -59,11 +59,6 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state) {
     case 'v':
         DBG_OK("setting log-level as warn.");
         cfg->logLevel = LOG_WARN;
-        break;
-
-    case 'i':
-        DBG_OK("setting log-level as info.");
-        cfg->logLevel = LOG_INFO;
         break;
         
     case 'c':


### PR DESCRIPTION
Because it seems unnecessary and perhaps LOG_INFO should be the default. That's what this code currently does, but I may change my mind later on the defaults.