### PR TITLE
Replace argp with getopt(3)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,24 +7,6 @@ include(CheckFunctionExists)
 set(CMAKE_REQUIRED_QUIET_SAVE ${CMAKE_REQUIRED_QUIET})
 set(CMAKE_REQUIRED_QUIET TRUE)
 
-check_function_exists("argp_parse" ARGP_IN_LIBC)
-if (ARGP_IN_LIBC)
-	set(ARGP_LIBRARIES "c" CACHE STRING "ARGP libraries.")
-	
-elseif (NOT ARGP_IN_LIBC)
-	unset(ARGP_IN_LIBC CACHE)
-
-	find_library(ARGP_LIB "argp")
-	mark_as_advanced(ARGP_LIB)
-	if (ARGP_LIB)
-		set(CMAKE_REQUIRED_LIBRARIES "${ARGP_LIB}")
-		check_function_exists("argp_parse" ARGP_EXTERNAL)
-		if (ARGP_EXTERNAL)
-			set(ARGP_LIBRARIES "${ARGP_LIB}" CACHE STRING "ARGP libraries.")
-		endif ()
-	endif ()
-endif ()
-
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wfatal-errors -Os -std=gnu11 -fstack-protector")
 
 find_package(OpenSSL REQUIRED)
@@ -75,4 +57,3 @@ set(SOURCE_FILES
 add_executable(xdccget ${SOURCE_FILES})
 target_link_libraries(xdccget ${OPENSSL_LIBRARIES})
 target_link_libraries (xdccget ${CMAKE_THREAD_LIBS_INIT})
-target_link_libraries (xdccget ${ARGP_LIBRARIES})

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 CFLAGS =-std=gnu99 -D_FILE_OFFSET_BITS=64 -DENABLE_SSL -DENABLE_IPV6 -DHAVE_POLL -Wall -Wfatal-errors -Os -fstack-protector -I libircclient-include/
 LIBS = -lssl -lcrypto -lpthread
-#LIBS += -largp
 PROG = xdccget
 
 SRCS = xdccget.c config.c helper.c argument_parser.c libircclient-src/libircclient.c sds.c dirs.c file.c hashing_algo.c sph_md5.c

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ the default parameters to your matters quickly.
 
 ## Compiling xdccget
 Compiling xdccget is just running make from the root folder of the repository. Please make sure, that you have installed
-the depended libraries (OpenSSL and for some systems argp-library) and use the correct Makefile for your system.
+the depended libraries (OpenSSL) and use the correct Makefile for your system.
 
 ### Ubuntu and derivants
 To compile xdccget under Ubuntu and other distros like Linux Mint you have to install the package libssl-dev with apt-get.
@@ -77,17 +77,7 @@ sudo apt-get install libssl-dev build-essential
 You need to make sure, that you have the openssl-development packages for you favorite distribution installed.
 
 ### OSX and BSD
-For osx and bsd systems you need to also install the development files for openssl. You need to install
-the library argp, which is used to parse command line arguments. Please make sure, that you rename the Makefile.FreeBSD
-for example to Makefile if you want to compile for FreeBSD.
-
-If you use pkg on FreeBSD for package-management you can issue the following command to install the required libs:
-
-```
-sudo pkg install gcc argp-standalone openssl
-```
-
-On OSX and other BSD variants you have to use an alternative way to install the packages.
+For osx and bsd systems you need to also install the development files for openssl.
 
 ## Configure xdccget
 You can configure some options with the config file. It is placed in the folder .xdccget in your home directory of your operating system. The following options are currently supported:

--- a/argument_parser.c
+++ b/argument_parser.c
@@ -71,13 +71,7 @@ void parseArguments(int argc, char **argv, struct xdccGetConfig *cfg) {
         }
     }
 
-    if (optind >= argc) {
-        logprintf(LOG_ERR, "%s\n", usage);
-        exit(EXIT_FAILURE);
-    }
-
-    if ((argc - optind) >= 3) {
-        /* Too many arguments. */
+    if (optind >= argc || (argc - optind) > 3) {
         logprintf(LOG_ERR, "%s\n", usage);
         exit(EXIT_FAILURE);
     }

--- a/argument_parser.c
+++ b/argument_parser.c
@@ -1,131 +1,90 @@
-#include <argp.h>
+#include <unistd.h>
 #include <strings.h>
 #include <stdlib.h>
 #include "helper.h"
 
 #include "argument_parser.h"
 
-
-const char *argp_program_version = "xdccget 1.0";
-const char *argp_program_bug_address ="<nobody@nobody.org>";
-
-/* Program documentation. */
-static char doc[] =
-"xdccget -- download from cmd with xdcc";
-
-/* A description of the arguments we accept. */
-static char args_doc[] = "<server> <channel(s)> <bot cmds>";
-
-#define OPT_ACCEPT_ALL_NICKS 1
-#define OPT_DONT_CONFIRM_OFFSETS 2
-
-
-/* The options we understand. */
-static struct argp_option options[] = {
-{"verbose",  'v', 0,      0,  "Produce verbose output", 0 },
-{"quiet",    'q', 0,      0,  "Don't produce any output", 0 },
-{"ipv4",   '4', 0,      0,  "Use ipv4 to connect to irc server.", 0 },
-#ifdef ENABLE_IPV6
-{"ipv6",   '6', 0,      0,  "Use ipv6 to connect to irc server.", 0 },
-#endif
-{"port",   'p', "<port number>",      0,  "Use the following port to connect to server. default is 6667.", 0 },
-{"directory",   'd', "<download-directory>",      0,  "Directory, where to place the files." , 0 },
-{"nick",   'n', "<nickname>",      0,  "Use this specific nickname while connecting to the irc-server.", 0 },
-{"login",   'l', "<login-command>",      0,  "Use this login-command to authorize your nick to the irc-server after connecting.", 0 },
-{"accept-all-nicks",   OPT_ACCEPT_ALL_NICKS, 0,      0,  "Accept DCC send requests from ALL bots and do not verify any nicknames of incoming dcc requests.", 0 },
-{"dont-confirm-offsets",   OPT_DONT_CONFIRM_OFFSETS, 0,      0,  "Do not send file offsets to the bots. Can be used on bots where the transfer gets stucked after a short while.", 0 },
-{ 0 }
-};
-
-static error_t parse_opt (int key, char *arg, struct argp_state *state);
-
-/* Our argp parser. */
-static struct argp argp = { options, parse_opt, args_doc, doc, NULL, NULL, NULL };
-
-/* Parse a single option. */
-static error_t parse_opt(int key, char *arg, struct argp_state *state) {
-    /* Get the input argument from argp_parse, which we
-      know is a pointer to our arguments structure. */
-    struct xdccGetConfig *cfg = state->input;
-    cfg->logLevel = LOG_INFO;
-
-    switch (key) {
-    case 'q':
-        DBG_OK("setting log-level as quiet.");
-        cfg->logLevel = LOG_QUIET;
-        break;
-
-    case 'v':
-        DBG_OK("setting log-level as warn.");
-        cfg->logLevel = LOG_WARN;
-        break;
-
-    case 'd':
-        DBG_OK("setting target dir as %s", arg);
-        cfg->targetDir = sdsnew(arg);
-        break;
-        
-    case 'n':
-        DBG_OK("setting nickname as %s", arg);
-        cfg->nick = sdsnew(arg);
-        break;
-        
-    case 'l':
-         DBG_OK("setting login-command as %s", arg);
-        cfg->login_command = sdsnew(arg);
-        break;
-
-    case 'p':
-        cfg->port = (unsigned short) strtoul(arg, NULL, 0);
-        DBG_OK("setting port as %u", cfg->port);
-        break;
-	
-    case OPT_ACCEPT_ALL_NICKS:
-        cfg_set_bit(cfg, ACCEPT_ALL_NICKS_FLAG);
-        break;
-    case OPT_DONT_CONFIRM_OFFSETS:
-	    cfg_set_bit(cfg, DONT_CONFIRM_OFFSETS_FLAG);
-	    break;
-    case '4':
-        cfg_set_bit(cfg, USE_IPV4_FLAG);
-        break;
-
-#ifdef ENABLE_IPV6
-    case '6':
-        cfg_set_bit(cfg, USE_IPV6_FLAG);
-        break;
-#endif
-
-    case ARGP_KEY_ARG:
-    {
-        if (state->arg_num >= 3)
-            /* Too many arguments. */
-            argp_usage(state);
-
-        cfg->args[state->arg_num] = arg;
-    }
-        break;
-
-    case ARGP_KEY_END:
-        if (state->arg_num < 3)
-            /* Not enough arguments. */
-            argp_usage(state);
-        break;
-
-    default:
-        return ARGP_ERR_UNKNOWN;
-    }
-    return 0;
-}
+static char* usage = "usage: xdccget [-46aDqv] [-n <nickname>] [-p <port number>]\n"
+                                    "[-l <login-command>] [-d <download-directory>]\n"
+				    "<server> <channel(s)> <bot cmds>";
 
 void parseArguments(int argc, char **argv, struct xdccGetConfig *cfg) {
-    /* Parse our arguments; every option seen by parse_opt will
-      be reflected in arguments. */
-    int ret = argp_parse(&argp, argc, argv, 0, 0, cfg);
+    int opt;
 
-	if (ret != 0) {
-		logprintf(LOG_ERR, "the parsing of the command line options failed");
-	}
+    cfg->logLevel = LOG_INFO;
+
+    while ((opt = getopt(argc, argv, "hqvd:n:l:p:aD46"))) {
+        switch (opt) {
+        case 'h':
+            logprintf(LOG_ERR, "%s\n", usage);
+            exit(EXIT_FAILURE);
+
+        case 'q':
+            DBG_OK("setting log-level as quiet.");
+            cfg->logLevel = LOG_QUIET;
+            break;
+    
+        case 'v':
+            DBG_OK("setting log-level as warn.");
+            cfg->logLevel = LOG_WARN;
+            break;
+    
+        case 'd':
+            DBG_OK("setting target dir as %s", optarg);
+            cfg->targetDir = sdsnew(optarg);
+            break;
+            
+        case 'n':
+            DBG_OK("setting nickname as %s", optarg);
+            cfg->nick = sdsnew(optarg);
+            break;
+            
+        case 'l':
+             DBG_OK("setting login-command as %s", optarg);
+            cfg->login_command = sdsnew(optarg);
+            break;
+    
+        case 'p':
+            cfg->port = (unsigned short) strtoul(optarg, NULL, 0);
+            DBG_OK("setting port as %u", cfg->port);
+            break;
+    	
+        case 'a':
+            cfg_set_bit(cfg, ACCEPT_ALL_NICKS_FLAG);
+            break;
+        case 'D':
+    	    cfg_set_bit(cfg, DONT_CONFIRM_OFFSETS_FLAG);
+    	    break;
+        case '4':
+            cfg_set_bit(cfg, USE_IPV4_FLAG);
+            break;
+    
+#ifdef ENABLE_IPV6
+        case '6':
+            cfg_set_bit(cfg, USE_IPV6_FLAG);
+            break;
+#endif
+	case '?':
+            logprintf(LOG_ERR, "%s\n", usage);
+            exit(EXIT_FAILURE);
+        }
+    }
+
+    if (optind >= argc) {
+        logprintf(LOG_ERR, "%s\n", usage);
+        exit(EXIT_FAILURE);
+    }
+
+    if ((argc - optind) >= 3) {
+        /* Too many arguments. */
+        logprintf(LOG_ERR, "%s\n", usage);
+        exit(EXIT_FAILURE);
+    }
+
+    for (int i = 0; (i + optind) <= argc; i++) {
+       cfg->args[i] = argv[i + optind];
+    }
 }
 
 struct dccDownload* newDccDownload(sds botNick, sds xdccCmd) {


### PR DESCRIPTION
This simplifies the build/code by reducing the need by one less dependency, argp. Additionally, by using getopt(3), it eliminates long options, so one more step towards being more "BSD."