### PR TITLE
Replace strncat(3)/strncpy(3) with the safer strlcat(3)/strlcpy(3)

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -29,6 +29,8 @@ jobs:
   ubuntu:
     runs-on: ubuntu-latest
     steps:
+    - name: Install libbsd-dev
+      run: sudo apt install libbsd-dev
     - name: Checkout repository
       uses: actions/checkout@v2
     - name: build

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -33,6 +33,9 @@ jobs:
         language: [ 'cpp' ]
 
     steps:
+    - name: Install libbsd-dev
+      run: sudo apt install libbsd-dev
+
     - name: Checkout repository
       uses: actions/checkout@v2
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PROG = xdccget
-LIBS = -lpthread `pkg-config --libs openssl`
+LIBS = -lpthread `pkg-config --libs openssl` `pkg-config --silence-errors --libs libbsd`
 CFLAGS += -std=gnu99 -D_FILE_OFFSET_BITS=64 -DENABLE_SSL -DENABLE_IPV6 -DHAVE_POLL -Wall -Wfatal-errors -Os -fstack-protector -Ilibircclient-include `pkg-config --cflags openssl`
 
 SRCS = xdccget.c \

--- a/argument_parser.c
+++ b/argument_parser.c
@@ -53,8 +53,8 @@ void parseDccDownload(char *dccDownloadString, char **nick, char **xdccCmd) {
     char nickPtr[nickLen];
     char xdccPtr[cmdLen];
 
-    strncpy(nickPtr, dccDownloadString, nickLen - 1);
-    strncpy(xdccPtr, dccDownloadString + (spaceFound + 1), cmdLen - 1);
+    strlcpy(nickPtr, dccDownloadString, sizeof(nickPtr));
+    strlcpy(xdccPtr, dccDownloadString + (spaceFound + 1), sizeof(xdccPtr));
 
     *nick = strdup(nickPtr);
     *xdccCmd = strdup(xdccPtr);

--- a/xdccget.c
+++ b/xdccget.c
@@ -205,14 +205,14 @@ static char * extractMD5 (const char *string) {
     char *md5sum = strstr(string, "md5sum");
 
     if (md5sum != NULL) {
-        strncpy(md5ChecksumString, md5sum+8, MD5_STR_SIZE);
+        strlcpy(md5ChecksumString, md5sum+8, sizeof(md5ChecksumString));
         return strdup(md5ChecksumString);
     }
 
     md5sum = strstr(string, "MD5");
 
     if (md5sum != NULL) {
-        strncpy(md5ChecksumString, md5sum+4, MD5_STR_SIZE);
+        strlcpy(md5ChecksumString, md5sum+4, sizeof(md5ChecksumString));
         return strdup(md5ChecksumString);
     }
 
@@ -248,10 +248,10 @@ void dump_event (irc_session_t * session, const char * event, irc_parser_result_
 
     for (cnt = 0; cnt < result->num_params; cnt++) {
         if (cnt)
-            strncat(param_string, "|", 1024 - strlen(param_string) - 1);
+            strlcat(param_string, "|", 1024);
 
         char *message_without_color_codes = irc_color_strip_from_mirc(result->params[cnt]);
-        strncat(param_string, message_without_color_codes, 1024 - strlen(param_string) - 1);
+        strlcat(param_string, message_without_color_codes, 1024);
         free(message_without_color_codes);
     }
 


### PR DESCRIPTION
The challenge with this is conditionally using libbsd-dev on Linux, because Linux does not provide these string functions by default. It should work by passing another `pkg-config` with `--silence-errors`.