### PR TITLE
Bring Your Own Buffer

### DIFF
--- a/libircclient/include/libircclient.h
+++ b/libircclient/include/libircclient.h
@@ -1109,6 +1109,30 @@ void irc_target_get_host (const char * target, char *nick, size_t size);
  */
 int	irc_dcc_accept (irc_session_t * session, irc_dcc_t dccid, void * ctx, irc_dcc_callback_t callback);
 
+/*!
+ * \fn int irc_dcc_read (irc_session_t * session, irc_dcc_t dccid, char * buffer, size_t capacity)
+ * \brief Read DCC data from the socket to a buffer.
+ *
+ * \param session An initiated and connected session.
+ * \param dccid   A DCC session ID, returned by appropriate callback.
+ * \param buffer  A pointer to a user-supplied buffer into which to copy
+ *                the DCC file data.
+ * \param capacity A user-supplied size of the buffer, indicating how
+ *                 much libircclient may store at the given buffer.
+ *
+ * \return The number of bytes that libircclient has writen to the supplied buffer if
+ *         the return value is non-negative. Otherwise, an error.
+ *
+ * This function reads data from the DCC socket and writes it into the supplied
+ * buffer, up to (and inclusing) the maximum number of bytes as specified by the
+ * capacity.
+ *
+ * This function should be called only during an active DCC session, but primarily
+ * during the `cb_datum` callback that is supplied to irc_dcc_accept.
+ *
+ * \ingroup dccstuff
+ */
+int irc_dcc_read (irc_session_t * session, irc_dcc_t dccid, char * buffer, size_t capacity);
 
 /*!
  * \fn int irc_dcc_decline (irc_session_t * session, irc_dcc_t dccid)

--- a/libircclient/include/libircclient.h
+++ b/libircclient/include/libircclient.h
@@ -82,8 +82,6 @@ typedef unsigned int			irc_dcc_t;
  * \param id  A DCC session id.
  * \param status An error status. 0 means no error, otherwise error code.
  * \param ctx A user-supplied context.
- * \param data Data supplied (if available)
- * \param length data length (if available)
  *
  * This callback is called for all DCC functions when state change occurs.
  *
@@ -116,7 +114,7 @@ typedef unsigned int			irc_dcc_t;
  *
  * \ingroup dccstuff
  */
-typedef void (*irc_dcc_callback_t) (irc_session_t * session, irc_dcc_t id, int status, void * ctx, const char * data, unsigned int length);
+typedef void (*irc_dcc_callback_t) (irc_session_t * session, irc_dcc_t id, int status, void * ctx);
 
 
 #define IN_INCLUDE_LIBIRC_H

--- a/libircclient/src/dcc.c
+++ b/libircclient/src/dcc.c
@@ -594,3 +594,23 @@ int irc_dcc_decline (irc_session_t * session, irc_dcc_t dccid)
 	libirc_mutex_unlock (&session->mutex_dcc);
 	return 0;
 }
+
+int irc_dcc_read (irc_session_t * session, irc_dcc_t dccid, char * buffer, size_t capacity)
+{
+	irc_dcc_session_t * dcc = libirc_find_dcc_session (session, dccid, 1);
+
+	if ( !dcc )
+		return -LIBIRC_ERR_INVAL;
+
+	int length = socket_recv (&dcc->sock, buffer, capacity);
+
+	if ( length < 0 )
+	{
+		return -LIBIRC_ERR_READ;
+	}
+	else
+	{
+	    dcc->file_confirm_offset += length;
+	    return length;
+	}
+}

--- a/libircclient/src/dcc.c
+++ b/libircclient/src/dcc.c
@@ -255,7 +255,7 @@ static void libirc_dcc_process_descriptors (irc_session_t * ircsession, fd_set *
 
 					libirc_mutex_unlock (&ircsession->mutex_dcc);
 
-					(*dcc->cb)(ircsession, dcc->id, 0, dcc->ctx, dcc->incoming_buf, offset);
+					(*dcc->cb)(ircsession, dcc->id, LIBIRC_ERR_OK, dcc->ctx, dcc->incoming_buf, offset);
 
 					/*
 					 * If the session is not terminated in callback,
@@ -346,7 +346,7 @@ static void libirc_dcc_process_descriptors (irc_session_t * ircsession, fd_set *
 							{
 								libirc_mutex_unlock (&ircsession->mutex_dcc);
 								libirc_mutex_unlock (&dcc->mutex_outbuf);
-								(*dcc->cb)(ircsession, dcc->id, 0, dcc->ctx, 0, 0);
+								(*dcc->cb)(ircsession, dcc->id, LIBIRC_ERR_OK, dcc->ctx, 0, 0);
 								libirc_dcc_destroy_nolock (ircsession, dcc->id);
 							}
 							else

--- a/libircclient/src/dcc.c
+++ b/libircclient/src/dcc.c
@@ -234,62 +234,24 @@ static void libirc_dcc_process_descriptors (irc_session_t * ircsession, fd_set *
 		{
 			if ( FD_ISSET (dcc->sock, in_set) )
 			{
-				int length, offset = 0, err = 0;
-		
-				unsigned int amount = sizeof (dcc->incoming_buf) - dcc->incoming_offset;
+				libirc_mutex_unlock (&ircsession->mutex_dcc);
 
-				length = socket_recv (&dcc->sock, dcc->incoming_buf + dcc->incoming_offset, amount);
-
-				if ( length < 0 )
-				{
-					err = LIBIRC_ERR_READ;
-				}	
-				else if ( length == 0 )
-				{
-					err = LIBIRC_ERR_CLOSED;
-				}
-				else
-				{
-					dcc->incoming_offset += length;
-					offset = dcc->incoming_offset;
-
-					libirc_mutex_unlock (&ircsession->mutex_dcc);
-
-					(*dcc->cb)(ircsession, dcc->id, LIBIRC_ERR_OK, dcc->ctx, dcc->incoming_buf, offset);
-
-					/*
-					 * If the session is not terminated in callback,
-					 * put the sent amount into the sent_packet_size_net_byteorder
-					 */
-					if ( dcc->state != LIBIRC_STATE_REMOVED )
-					{
-						dcc->state = LIBIRC_STATE_CONFIRM_SIZE;
-						dcc->file_confirm_offset += offset;
-
-						// Store as big endian
-						dcc->outgoing_file_confirm_offset = htonl(dcc->file_confirm_offset);
-						dcc->outgoing_offset = sizeof(dcc->outgoing_file_confirm_offset);
-					}
-
-					libirc_mutex_lock (&ircsession->mutex_dcc);
-
-					if ( dcc->incoming_offset - offset > 0 )
-						memmove (dcc->incoming_buf, dcc->incoming_buf + offset, dcc->incoming_offset - offset);
-
-					dcc->incoming_offset -= offset;
-				}
+				(*dcc->cb)(ircsession, dcc->id, LIBIRC_ERR_OK, dcc->ctx, dcc->incoming_buf, 0);
 
 				/*
-				 * If error arises somewhere above, we inform the caller 
-				 * of failure, and destroy this session.
+				 * If the session is not terminated in callback,
+				 * put the sent amount into the sent_packet_size_net_byteorder
 				 */
-				if ( err )
+				if ( dcc->state != LIBIRC_STATE_REMOVED )
 				{
-					libirc_mutex_unlock (&ircsession->mutex_dcc);
-					(*dcc->cb)(ircsession, dcc->id, err, dcc->ctx, 0, 0);
-					libirc_mutex_lock (&ircsession->mutex_dcc);
-					libirc_dcc_destroy_nolock (ircsession, dcc->id);
+					dcc->state = LIBIRC_STATE_CONFIRM_SIZE;
+
+					// Store as big endian
+					dcc->outgoing_file_confirm_offset = htonl(dcc->file_confirm_offset);
+					dcc->outgoing_offset = sizeof(dcc->outgoing_file_confirm_offset);
 				}
+
+				libirc_mutex_lock (&ircsession->mutex_dcc);
 			}
 
 			/*

--- a/libircclient/src/dcc.c
+++ b/libircclient/src/dcc.c
@@ -111,7 +111,7 @@ static void libirc_dcc_add_descriptors (irc_session_t * ircsession, fd_set *in_s
 				libirc_mutex_unlock (&ircsession->mutex_dcc);
 
 				if ( dcc->cb )
-					(*dcc->cb)(ircsession, dcc->id, LIBIRC_ERR_TIMEOUT, dcc->ctx, 0, 0);
+					(*dcc->cb)(ircsession, dcc->id, LIBIRC_ERR_TIMEOUT, dcc->ctx);
 
 				libirc_mutex_lock (&ircsession->mutex_dcc);
 			}
@@ -236,7 +236,7 @@ static void libirc_dcc_process_descriptors (irc_session_t * ircsession, fd_set *
 			{
 				libirc_mutex_unlock (&ircsession->mutex_dcc);
 
-				(*dcc->cb)(ircsession, dcc->id, LIBIRC_ERR_OK, dcc->ctx, dcc->incoming_buf, 0);
+				(*dcc->cb)(ircsession, dcc->id, LIBIRC_ERR_OK, dcc->ctx);
 
 				/*
 				 * If the session is not terminated in callback,
@@ -308,7 +308,7 @@ static void libirc_dcc_process_descriptors (irc_session_t * ircsession, fd_set *
 							{
 								libirc_mutex_unlock (&ircsession->mutex_dcc);
 								libirc_mutex_unlock (&dcc->mutex_outbuf);
-								(*dcc->cb)(ircsession, dcc->id, LIBIRC_ERR_OK, dcc->ctx, 0, 0);
+								(*dcc->cb)(ircsession, dcc->id, LIBIRC_ERR_OK, dcc->ctx);
 								libirc_dcc_destroy_nolock (ircsession, dcc->id);
 							}
 							else
@@ -329,7 +329,7 @@ static void libirc_dcc_process_descriptors (irc_session_t * ircsession, fd_set *
 				if ( err )
 				{
 					libirc_mutex_unlock (&ircsession->mutex_dcc);
-					(*dcc->cb)(ircsession, dcc->id, err, dcc->ctx, 0, 0);
+					(*dcc->cb)(ircsession, dcc->id, err, dcc->ctx);
 					libirc_mutex_lock (&ircsession->mutex_dcc);
 					libirc_dcc_destroy_nolock (ircsession, dcc->id);
 				}

--- a/xdccget.c
+++ b/xdccget.c
@@ -158,7 +158,7 @@ print_progress(struct xdccGetConfig *cfg, unsigned int chunk_size_bytes)
 }
 
 void
-callback_dcc_recv_file(irc_session_t *session, irc_dcc_t id, int status, void *fstream, const char *data, unsigned int length)
+callback_dcc_recv_file(irc_session_t *session, irc_dcc_t id, int status, void *fstream)
 {
     assert(session);
     assert(fstream);
@@ -169,10 +169,6 @@ callback_dcc_recv_file(irc_session_t *session, irc_dcc_t id, int status, void *f
 
     if (status) {
         warnx("failed to download file: %s", irc_strerror(status));
-        irc_cmd_quit(session, NULL);
-        return;
-    }
-    if (!data) {
         irc_cmd_quit(session, NULL);
         return;
     }


### PR DESCRIPTION
This PR is mostly about "inverting the control" of libircclient when it comes to reading from the DCC buffer. Traditionally, libircclient would call a callback after reading up to 1 KiB of data from the socket. This leads to many function calls and probably quite a bit of overhead just to write up to 1 KiB of data.

This PR will invert that order by calling the callback when there is data to be read from the socket and then having the callback use its own pre-sized buffer to read the data from the socket. I hope that this will lead to less callback function calls and lead to more data being written to file.