### PR TITLE
Emit results from Infer's scan as SARIF

### DIFF
--- a/.github/workflows/infer.yml
+++ b/.github/workflows/infer.yml
@@ -30,4 +30,9 @@ jobs:
           ninja -C build
 
       - name: Run Infer
-        run: infer --compilation-database build/compile_commands.json
+        run: infer --sarif --compilation-database build/compile_commands.json
+
+      - name: Upload SARIF
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: infer-out/report.sarif


### PR DESCRIPTION
SARIF is the universal format for static analysis tools, and it is consumable by GitHub Code Scanning, which means I can understand the results much better.