### PR TITLE
Modified libircclient to accept a callback at the end of a DCC transfer.

### DIFF
--- a/libircclient/include/libircclient.h
+++ b/libircclient/include/libircclient.h
@@ -1080,15 +1080,18 @@ void irc_target_get_host (const char * target, char *nick, size_t size);
 
 
 /*!
- * \fn int irc_dcc_accept (irc_session_t * session, irc_dcc_t dccid, void * ctx, irc_dcc_callback_t callback)
+ * \fn int irc_dcc_accept (irc_session_t * session, irc_dcc_t dccid, void * ctx, irc_dcc_callback_t cb_datum, irc_dcc_callback_t cb_close)
  * \brief Accepts a remote DCC CHAT or DCC RECVFILE request.
  *
  * \param session An initiated and connected session.
  * \param dccid   A DCC session ID, returned by appropriate callback.
  * \param ctx     A user-supplied DCC session context, which will be passed 
  *                to the DCC callback function. May be NULL.
- * \param callback A DCC callback function, which will be called when 
+ * \param cb_datum A DCC callback function, which will be called when
  *                anything is said by other party. Must not be NULL.
+ * \param cb_close A DCC callback function, which will be called when
+ *                 the DCC transmission has been fully received or sent.
+ *                 May be NULL.
  *
  * \return Return code 0 means success. Other value means error, the error 
  *  code may be obtained through irc_errno().
@@ -1107,7 +1110,7 @@ void irc_target_get_host (const char * target, char *nick, size_t size);
  * \sa irc_dcc_decline event_dcc_chat_req event_dcc_send_req
  * \ingroup dccstuff
  */
-int	irc_dcc_accept (irc_session_t * session, irc_dcc_t dccid, void * ctx, irc_dcc_callback_t callback);
+int	irc_dcc_accept (irc_session_t * session, irc_dcc_t dccid, void * ctx, irc_dcc_callback_t cb_datum, irc_dcc_callback_t cb_close);
 
 
 /*!

--- a/libircclient/src/dcc.h
+++ b/libircclient/src/dcc.h
@@ -45,7 +45,8 @@ struct irc_dcc_session_s
 	unsigned int		outgoing_offset;
 	port_mutex_t		mutex_outbuf;
 
-	irc_dcc_callback_t	cb;
+	irc_dcc_callback_t	cb_datum;
+	irc_dcc_callback_t	cb_close;
 };
 
 

--- a/xdccget.c
+++ b/xdccget.c
@@ -185,7 +185,7 @@ callback_dcc_recv_file(irc_session_t *session, irc_dcc_t id, int status, void *f
 }
 
 void
-callback_dcc_close(irc_session_t *session, irc_dcc_t id, int status, void *fstream, const char *data, unsigned int length)
+callback_dcc_close(irc_session_t *session, irc_dcc_t id, int status, void *fstream)
 {
     assert(session);
     assert(fstream);

--- a/xdccget.c
+++ b/xdccget.c
@@ -168,16 +168,21 @@ callback_dcc_recv_file(irc_session_t *session, irc_dcc_t id, int status, void *f
         irc_cmd_quit(session, NULL);
         return;
     }
-    if (!data) {
-        irc_cmd_quit(session, NULL);
-        return;
-    }
 
     fwrite(data, sizeof(char), length, fstream);
 
     struct xdccGetConfig *cfg = irc_get_ctx(session);
     cfg->currsize += length;
     print_progress(cfg, length);
+}
+
+void
+callback_dcc_close(irc_session_t *session, irc_dcc_t id, int status, void *fstream, const char *data, unsigned int length)
+{
+    assert(session);
+    assert(fstream);
+
+    irc_cmd_quit(session, NULL);
 }
 
 void
@@ -199,7 +204,7 @@ event_dcc_send_req(irc_session_t *session, const char *nick, const char *addr, c
         return;
     }
 
-    irc_dcc_accept(session, dccid, fstream, callback_dcc_recv_file);
+    irc_dcc_accept(session, dccid, fstream, callback_dcc_recv_file, callback_dcc_close);
 
     struct xdccGetConfig *cfg = irc_get_ctx(session);
     strlcpy(&cfg->filename[0], filename, sizeof(cfg->filename));


### PR DESCRIPTION
This makes the application code, xdccget.c, slightly easier to read, as we now don't need to check on every call to `callback_dcc_recv_file` whether it's the end of the transfer or not. Bonus point: it saves another branch, but that's probably just small potatoes :)