### PR TITLE
Added `-A` flag to disable DCC acknowledgements.

### DIFF
--- a/libircclient/include/libircclient.h
+++ b/libircclient/include/libircclient.h
@@ -44,6 +44,7 @@
 #ifndef INCLUDE_LIBIRC_H
 #define INCLUDE_LIBIRC_H
 
+#include <stdbool.h>
 #include <stdlib.h>
 #include <sys/select.h>	/* fd_set */
 
@@ -1078,7 +1079,7 @@ void irc_target_get_host (const char * target, char *nick, size_t size);
 
 
 /*!
- * \fn int irc_dcc_accept (irc_session_t * session, irc_dcc_t dccid, void * ctx, irc_dcc_callback_t cb_datum, irc_dcc_callback_t cb_close)
+ * \fn int irc_dcc_accept (irc_session_t * session, irc_dcc_t dccid, void * ctx, irc_dcc_callback_t cb_datum, irc_dcc_callback_t cb_close, bool acknowledge)
  * \brief Accepts a remote DCC CHAT or DCC RECVFILE request.
  *
  * \param session An initiated and connected session.
@@ -1090,6 +1091,9 @@ void irc_target_get_host (const char * target, char *nick, size_t size);
  * \param cb_close A DCC callback function, which will be called when
  *                 the DCC transmission has been fully received or sent.
  *                 May be NULL.
+ * \param acknowledge A boolean flag to indicate whether libircclient should
+ *                    send file offsets as acknowledgements. Although it is protocol,
+ *                    to send file offsets, some DCC senders do not require them.
  *
  * \return Return code 0 means success. Other value means error, the error 
  *  code may be obtained through irc_errno().
@@ -1108,7 +1112,7 @@ void irc_target_get_host (const char * target, char *nick, size_t size);
  * \sa irc_dcc_decline event_dcc_chat_req event_dcc_send_req
  * \ingroup dccstuff
  */
-int	irc_dcc_accept (irc_session_t * session, irc_dcc_t dccid, void * ctx, irc_dcc_callback_t cb_datum, irc_dcc_callback_t cb_close);
+int	irc_dcc_accept (irc_session_t * session, irc_dcc_t dccid, void * ctx, irc_dcc_callback_t cb_datum, irc_dcc_callback_t cb_close, bool acknowledge);
 
 /*!
  * \fn int irc_dcc_read (irc_session_t * session, irc_dcc_t dccid, char * buffer, size_t capacity)

--- a/libircclient/src/dcc.h
+++ b/libircclient/src/dcc.h
@@ -15,6 +15,7 @@
 #ifndef INCLUDE_IRC_DCC_H
 #define INCLUDE_IRC_DCC_H
 
+#include <stdbool.h>
 
 /*
  * This structure keeps the state of a single DCC connection.
@@ -29,6 +30,8 @@ struct irc_dcc_session_s
 
 	int			state;
 	time_t			timeout;
+
+	bool			acknowledge;
 
 	uint64_t		received_file_size;
 	uint64_t		file_confirm_offset;

--- a/xdccget.c
+++ b/xdccget.c
@@ -77,6 +77,7 @@ struct xdccGetConfig {
     uint64_t currsize;
     uint32_t pack;
     bool is_ircs;
+    bool no_ack;
 };
 
 void
@@ -212,16 +213,16 @@ event_dcc_send_req(irc_session_t *session, const char *nick, const char *addr, c
         return;
     }
 
-    irc_dcc_accept(session, dccid, fstream, callback_dcc_recv_file, callback_dcc_close);
-
     struct xdccGetConfig *cfg = irc_get_ctx(session);
     strlcpy(&cfg->filename[0], filename, sizeof(cfg->filename));
     cfg->filesize = size;
+
+    irc_dcc_accept(session, dccid, fstream, callback_dcc_recv_file, callback_dcc_close, !cfg->no_ack);
 }
 
 void
 usage(int exit_status) {
-    fputs("usage: xdccget <uri> <nick> send <pack>\n", stderr);
+    fputs("usage: xdccget [-A] <uri> <nick> send <pack>\n", stderr);
     exit(exit_status);
 }
 
@@ -231,8 +232,11 @@ main(int argc, char **argv)
     struct xdccGetConfig cfg = {0};
 
     int opt;
-    while ((opt = getopt(argc, argv, "Vh")) != -1) {
+    while ((opt = getopt(argc, argv, "AVh")) != -1) {
         switch (opt) {
+	    case 'A':
+		cfg.no_ack = true;
+		break;
             case 'V': {
                 unsigned int major, minor;
                 irc_get_version(&major, &minor);


### PR DESCRIPTION
This does primarily two things:

1. It allows xdccget to download files greater than ~180 MiB. This limitation was due to silly DCC senders not reading/receiving their DCC acknowledgements and instead letting them queue up in the TCP buffer, which ultimately meant RSTing the connection.

2. Gives a *slight* performance boost as the client and sender no longer need to calculate or process these file offsets.

Importantly, this flag is not enabled by default because it is going against DCC "protocol" to ignore DCC acknowledgements (even if it is typically useful).