### PR TITLE
Use mmap(2) to write the download to file

### DIFF
--- a/libircclient/src/dcc.h
+++ b/libircclient/src/dcc.h
@@ -27,6 +27,7 @@ struct irc_dcc_session_s
 	irc_dcc_t		id;
 	void			* ctx;
 	socket_t		sock;		/*!< DCC socket */
+	int			sock_rcvbuf_size;
 
 	int			state;
 	time_t			timeout;

--- a/xdccget.c
+++ b/xdccget.c
@@ -82,7 +82,7 @@ callback_dcc_recv_file(irc_session_t *session, irc_dcc_t id, int status, void *a
         return;
     }
 
-    if ((nread = irc_dcc_read(session, id, addr + cfg->currsize, cfg->filesize - cfg->currsize)) < 0) {
+    if ((nread = irc_dcc_read(session, id, (char *)addr + cfg->currsize, cfg->filesize - cfg->currsize)) < 0) {
 	warnx("irc_dcc_read: socket read error");
 	return;
     }

--- a/xdccget.h
+++ b/xdccget.h
@@ -32,6 +32,9 @@ struct xdccGetConfig {
 	// The current size of the DCC file (as it is being sent).
 	irc_dcc_size_t currsize;
 
+	// The file descriptor of the file to be downloaded.
+	int fd;
+
 	// The requested pack number.
 	uint32_t pack;
 


### PR DESCRIPTION
Using mmap(2) has the benefit that we do not need to buffer the data so many times (i.e. between the recv(2) and the fwrite(3)). Ultimately, I think this method simplifies the design and speeds up the download.