### PR TITLE
Revert "Use mmap(2) to write the download to file."

### DIFF
--- a/libircclient/src/dcc.c
+++ b/libircclient/src/dcc.c
@@ -14,7 +14,6 @@
 #include <inttypes.h>
 #include <arpa/inet.h>
 #include <stdbool.h>
-#include <sys/socket.h>
 
 static irc_dcc_session_t * libirc_find_dcc_session (irc_session_t * session, irc_dcc_t dccid, int lock_list)
 {
@@ -578,19 +577,7 @@ int irc_dcc_read (irc_session_t * session, irc_dcc_t dccid, char * buffer, size_
 	if ( !dcc )
 		return -LIBIRC_ERR_INVAL;
 
-	size_t recv_limit;
-
-	// Unfortunately, we cannot simply pass `capacity` to recv(2), since very large values may result in EINVAL.
-	if ( capacity > dcc->sock_rcvbuf_size )
-	{
-		recv_limit = dcc->sock_rcvbuf_size;
-	}
-	else
-	{
-		recv_limit = capacity;
-	}
-
-	int length = recv (dcc->sock, buffer, recv_limit, 0);
+	int length = socket_recv (&dcc->sock, buffer, capacity);
 
 	if ( length < 0 )
 	{

--- a/xget.h
+++ b/xget.h
@@ -32,9 +32,6 @@ struct xdccGetConfig
 	// The current size of the DCC file (as it is being sent).
 	irc_dcc_size_t currsize;
 
-	// The file descriptor of the file to be downloaded.
-	int fd;
-
 	// The requested pack number.
 	uint32_t pack;
 


### PR DESCRIPTION
This commit reverts commit 100d66fc7e07f4a2a47212332c12ce85b959935b. As much as I like the semantics and elegance of mmap(2), it has some gotchas that I would rather avoid.